### PR TITLE
Feature/update runtime nodejs14.x

### DIFF
--- a/modules/monitor/main.tf
+++ b/modules/monitor/main.tf
@@ -1,6 +1,8 @@
 module "lambda" {
   source  = "opendevsecops/lambda/aws"
-  version = "1.0.0"
+  version = "2.0.0"
+
+  runtime = "nodejs14.x"
 
   source_dir  = "${path.module}/src"
   output_path = "${path.module}/build/lambda.zip"

--- a/modules/monitor/main.tf
+++ b/modules/monitor/main.tf
@@ -5,7 +5,7 @@ module "lambda" {
   runtime = "nodejs14.x"
 
   source_dir  = "${path.module}/src"
-  output_path = "${path.module}/build/lambda.zip"
+  output_dir = "${path.module}/build/lambda.zip"
 
   name      = var.name
   role_name = var.role_name


### PR DESCRIPTION
## What? 
### Commits on Nov 18, 2021
- updating lambda tf module to 2.0.0 and runtime to nodejs14.x - @exequielrafaela
- updating module parameter definition - @exequielrafaela

## Why?
To fix 👇🏼 

```
│ Error: error creating Lambda Function (1): InvalidParameterValueException: The runtime parameter of nodejs10.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs14.x) while creating or updating functions.
│ {
│   RespMetadata: {
│     StatusCode: 400,
│     RequestID: "22d6cefb-41c4-46eb-a58c-2f4b86a9596c"
│   },
│   Message_: "The runtime parameter of nodejs10.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs14.x) while creating or updating functions.",
│   Type: "User"
│ }  
```
